### PR TITLE
Markdown-driven dev stories

### DIFF
--- a/app/dev-stories/[slug]/page.tsx
+++ b/app/dev-stories/[slug]/page.tsx
@@ -2,24 +2,11 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { readFile } from "fs/promises";
-import path from "path";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import { STORIES, storyCover } from "@/lib/stories";
+import { getStories, getStory } from "@/lib/stories";
 
 type Params = { slug: string };
-
-// Read a post's article text from content/stories/<id>.md at build time.
-// Returns "" if the file doesn't exist yet (so the page still builds).
-async function loadStoryBody(id: string): Promise<string> {
-  try {
-    const file = path.join(process.cwd(), "content", "stories", `${id}.md`);
-    return await readFile(file, "utf8");
-  } catch {
-    return "";
-  }
-}
 
 // Turn **bold** and *italic* markers inside a line into real formatting.
 function renderInline(text: string, keyBase: string) {
@@ -38,7 +25,7 @@ function renderInline(text: string, keyBase: string) {
 // Matches a numbered-list line, e.g. "1. First item".
 const ORDERED_ITEM = /^\d+\.\s+/;
 
-// Render a story's `body` text (see lib/stories.ts for the markers):
+// Render a story's article text (see lib/stories.ts for the markers):
 //   "## "  -> subheading        "### "  -> smaller subheading
 //   "> "   -> pull-quote        "- "    -> bullet list item
 //   "1. "  -> numbered list      anything else -> a paragraph
@@ -108,7 +95,7 @@ function PostBody({ body }: { body: string }) {
 }
 
 export function generateStaticParams(): Params[] {
-  return STORIES.map((s) => ({ slug: s.id }));
+  return getStories().map((s) => ({ slug: s.id }));
 }
 
 export async function generateMetadata({
@@ -117,7 +104,7 @@ export async function generateMetadata({
   params: Promise<Params>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const story = STORIES.find((s) => s.id === slug);
+  const story = getStory(slug);
   return {
     title: story
       ? `${story.title} · Dev Stories · Galactic Fleet`
@@ -131,12 +118,12 @@ export default async function PostPage({
   params: Promise<Params>;
 }) {
   const { slug } = await params;
-  const idx = STORIES.findIndex((s) => s.id === slug);
-  if (idx < 0) notFound();
-  const story = STORIES[idx];
-  const body = await loadStoryBody(story.id);
-  const prev = idx > 0 ? STORIES[idx - 1] : null;
-  const next = idx < STORIES.length - 1 ? STORIES[idx + 1] : null;
+  const story = getStory(slug);
+  if (!story) notFound();
+  const stories = getStories();
+  const idx = stories.findIndex((s) => s.id === slug);
+  const prev = idx > 0 ? stories[idx - 1] : null;
+  const next = idx < stories.length - 1 ? stories[idx + 1] : null;
 
   return (
     <>
@@ -154,13 +141,13 @@ export default async function PostPage({
 
           <div className="post-hero">
             <img
-              src={storyCover(story)}
+              src={story.cover}
               alt={`${story.title} hero`}
               style={{ objectPosition: story.coverPosition }}
             />
           </div>
 
-          <PostBody body={body} />
+          <PostBody body={story.body} />
 
           <nav className="post-nav" aria-label="Post navigation">
             {prev ? (

--- a/app/dev-stories/page.tsx
+++ b/app/dev-stories/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import { STORIES, storyCover } from "@/lib/stories";
+import { getStories } from "@/lib/stories";
 import { devStories } from "@/lib/content";
 
 export const metadata: Metadata = { title: "Dev Stories · Galactic Fleet" };
@@ -19,7 +19,7 @@ export default function DevStoriesIndex() {
           </header>
 
           <ol className="story-list" aria-label="All dev stories">
-            {STORIES.map((s) => (
+            {getStories().map((s) => (
               <li key={s.id} className="story-row">
                 <Link
                   className="story-row-thumb"
@@ -27,7 +27,7 @@ export default function DevStoriesIndex() {
                   aria-label={`Open ${s.title}`}
                 >
                   <img
-                    src={storyCover(s)}
+                    src={s.cover}
                     alt={`${s.title} cover`}
                     style={{ objectPosition: s.coverPosition }}
                   />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import ScrollReveal from "@/components/ScrollReveal";
 import DevStoriesCarousel from "@/components/DevStoriesCarousel";
 import ChannelIcon from "@/components/ChannelIcon";
 import { home, contact, channelLogoStyle } from "@/lib/content";
+import { getStories } from "@/lib/stories";
 
 export default function Home() {
   return (
@@ -40,7 +41,7 @@ export default function Home() {
           </div>
         </section>
 
-        <DevStoriesCarousel />
+        <DevStoriesCarousel stories={getStories()} />
 
         <section className="section contact" id="contact">
           <h2 className="reveal">{home.contactHeading}</h2>

--- a/components/DevStoriesCarousel.tsx
+++ b/components/DevStoriesCarousel.tsx
@@ -2,9 +2,11 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { STORIES, storyCover, type Story } from "@/lib/stories";
+import type { Story } from "@/lib/stories";
 
-export default function DevStoriesCarousel() {
+// Stories are loaded from content/stories/*.md on the server (lib/stories.ts)
+// and passed in here, because this client component can't read the filesystem.
+export default function DevStoriesCarousel({ stories }: { stories: Story[] }) {
   const [perPage, setPerPage] = useState(3);
   const [pos, setPos] = useState(1);
   const [animate, setAnimate] = useState(true);
@@ -24,11 +26,11 @@ export default function DevStoriesCarousel() {
 
   const pages = useMemo<Story[][]>(() => {
     const out: Story[][] = [];
-    for (let i = 0; i < STORIES.length; i += perPage) {
-      out.push(STORIES.slice(i, i + perPage));
+    for (let i = 0; i < stories.length; i += perPage) {
+      out.push(stories.slice(i, i + perPage));
     }
     return out;
-  }, [perPage]);
+  }, [stories, perPage]);
 
   const totalPages = pages.length;
 
@@ -146,7 +148,7 @@ export default function DevStoriesCarousel() {
                     <h3>{s.title}</h3>
                     <div className="story-thumb">
                       <img
-                        src={storyCover(s)}
+                        src={s.cover}
                         alt={`${s.title} cover`}
                         style={{ objectPosition: s.coverPosition }}
                       />

--- a/content/stories/casim.md
+++ b/content/stories/casim.md
@@ -1,41 +1,31 @@
-<!--
-  ARCHIVED DRAFT — not shown on the website.
-  Files in content/drafts/ are ignored by the site (the dev-stories pages only
-  read content/stories/<id>.md).
-
-  TO RESTORE THIS POST LATER:
-    1. Move this file to: content/stories/casim.md
-       (and delete this <!-- ... --> comment block).
-    2. Add this entry back into the STORIES list in lib/stories.ts:
-         {
-           id: "casim",
-           title: "A Living World: Rewriting CASIM in Rust",
-           brief: "How rewriting CASIM in Rust enabled the game's core design to come to life. ",
-         },
-    3. Cover image already exists at public/assets/placeholders/casim.svg
--->
+---
+title: A Living World: Rewriting CASIM in Rust
+brief: How rewriting CASIM in Rust enabled the game's core design to come to life.
+order: 4
+draft: true
+---
 
 ## How we rebuilt the heart of a large scale MMO in Rust — and made the world itself the game:
 
-One of our biggest projects with our long-term partner is working on a large-scale MMO RPG which is currently in early access. Since the very start of the project, the core design indicated that the game world should be central to the experience, acting as a key element of gameplay rather than simply a backdrop. A living and evolving world relies on a single piece of technology - CASIM, Cell Automator Simulator. 
+One of our biggest projects with our long-term partner is working on a large-scale MMO RPG which is currently in early access. Since the very start of the project, the core design indicated that the game world should be central to the experience, acting as a key element of gameplay rather than simply a backdrop. A living and evolving world relies on a single piece of technology - CASIM, Cell Automator Simulator.
 ## What does CASIM DO?
 So what does CASIM actually do? CASIM thinks of the world as a 3D grid of cells, and simulates them accordingly. These simulations are recalculated 10 times a second, leading to high fidelity updates. The question then becomes, what gets updated? That is the power of having a strong CASIM system, the list grows as design needs it to. Water flows, pools, and even erodes. Heat rises, melts, and affects materials around it. Objects can fall and slide differently depending on the gravity and other things around them. Our CASIM system is built to support an ever growing game, leading to many unique opportunities for future feature integration and support. The world is such a central element to the game. That is why it is important to create a robust solution and approach rather than a series of patchwork stopgaps.
 ## The problem we inherited:
 When we joined the project, CASIM was written in C#. It worked well for a prototype, but the team had much bigger goals for the simulation.
 We needed the system to:
-run at 10 iterations per second consistently
-scale from 128³ worlds to 1024³ and beyond
-reduce memory and garbage collection issues
-stay maintainable as new systems were added
-work across Linux, Mac, and Windows
+- run at 10 iterations per second consistently
+- scale from 128³ worlds to 1024³ and beyond
+- reduce memory and garbage collection issues
+- stay maintainable as new systems were added
+- work across Linux, Mac, and Windows
 At a certain point, the prototype had reached its limits. Pushing performance further was becoming more expensive and harder to maintain.
 ## Why Rust?
 We chose Rust for four simple reasons.
 Rust gave us:
--Resource management (CPU, memory, threading) without significant or random overhead (garbage collection…)
--significantly better performance
--strong multi-threading support
--easier cross-platform development
+- Resource management (CPU, memory, threading) without significant or random overhead (garbage collection…)
+- significantly better performance
+- strong multi-threading support
+- easier cross-platform development
 None of us were Rust experts when we started. That’s worth saying out loud.
 We learned while building, refactored systems multiple times, and improved the architecture as our understanding of the language grew.
 That process ended up making the system stronger in the long run.
@@ -46,11 +36,11 @@ A fast simulation isn't worth much if nothing else can be read from it. The next
 The fix had two parts. First, we restructured how CASIM uses memory and CPU cores so that simulation work and data-serving work don't block each other. Second, instead of pushing the entire world state to consumers, we send deltas — only what changed since last iteration. The network layer became as much of a design problem as the simulation itself, and ended up being one of the most efficient pieces of the system.
 ## Where we landed
 The rewrite gave us:
--1024m³ simulated worlds running at 10 iterations per second
--a cleaner and more extendable simulation framework
--multi-threaded optimization across cores
--full cross-platform support
--a lightweight networking layer for world updates
+- 1024m³ simulated worlds running at 10 iterations per second
+- a cleaner and more extendable simulation framework
+- multi-threaded optimization across cores
+- full cross-platform support
+- a lightweight networking layer for world updates
 It also made adding new systems significantly easier. Gas simulation, for example, was added later as a test of how flexible the architecture had become.
 ## The bonus we didn't fully see coming
 Originally, the plan was for CASIM to communicate with Unity through external services. But because Rust supports so many targets, we were able to compile client binaries that run directly inside Unity itself. That moved a major part of the project away from Unity’s runtime limitations and onto a faster, more memory-efficient foundation. Sometimes a good technical decision solves more problems than you originally planned for.

--- a/content/stories/lookingup.md
+++ b/content/stories/lookingup.md
@@ -1,3 +1,11 @@
+---
+title: Looking Up: Our First Game
+brief: We didn’t just build our first game — we learned how to make games by making it.
+cover: /assets/placeholders/lookingup.png
+coverPosition: left
+order: 2
+---
+
 ##  From Idea to Game: How Looking Up Came to Life
 Before Looking Up became the cozy puzzle game it is today, it existed in many completely different forms. At one point, it was a game about playful monsters. Another version leaned into a witchy atmosphere. Some concepts even focused on crafting mechanics instead of puzzles. Like many first projects, we started with ideas that were exciting, ambitious, and far beyond what our team could realistically build at the time. That became our first major challenge: figuring out not only what kind of game we wanted to make, but what kind of game we were actually capable of making.
 

--- a/content/stories/story-1.md
+++ b/content/stories/story-1.md
@@ -1,1 +1,7 @@
+---
+title: Loading...
+brief: This story isn't quite ready yet, we thank you for your patience.
+order: 1
+---
+
 ## Coming soon!

--- a/content/stories/story-3.md
+++ b/content/stories/story-3.md
@@ -1,1 +1,7 @@
+---
+title: Loading...
+brief: This story isn't quite ready yet, we thank you for your patience.
+order: 3
+---
+
 ## Coming soon!

--- a/content/stories/story-4.md
+++ b/content/stories/story-4.md
@@ -1,1 +1,8 @@
+---
+title: Story 4 headline here
+brief: One-line summary here.
+order: 4
+draft: true
+---
+
 Paste your Story 4 article here.

--- a/content/stories/story-5.md
+++ b/content/stories/story-5.md
@@ -1,1 +1,8 @@
+---
+title: Story 5 headline here
+brief: One-line summary here.
+order: 5
+draft: true
+---
+
 Paste your Story 5 article here.

--- a/content/stories/story-6.md
+++ b/content/stories/story-6.md
@@ -1,1 +1,8 @@
+---
+title: Story 6 headline here
+brief: One-line summary here.
+order: 6
+draft: true
+---
+
 Paste your Story 6 article here.

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -13,7 +13,8 @@
 //    • For an apostrophe inside text, write it normally: "We're".
 //    • Blank a line out by leaving empty quotes: "".
 //
-//  Blog / Dev Story posts live in their own file: lib/stories.ts
+//  Blog / Dev Story posts live in Markdown files: content/stories/<id>.md
+//  (see lib/stories.ts for instructions).
 // ============================================================================
 
 import type { CSSProperties } from "react";
@@ -191,7 +192,8 @@ export const play = {
 
 // ---------------------------------------------------------------------------
 //  DEV STORIES INDEX  ("/dev-stories")  — the list page heading.
-//  The actual posts (titles, dates, bodies) live in lib/stories.ts
+//  The actual posts live in Markdown files: content/stories/<id>.md
+//  (see lib/stories.ts for instructions).
 // ---------------------------------------------------------------------------
 export const devStories = {
   eyebrow: "Field notes from orbit",

--- a/lib/stories.ts
+++ b/lib/stories.ts
@@ -1,71 +1,140 @@
 // ============================================================================
-//  DEV STORIES / BLOG POSTS  —  the post LIST lives here.
+//  DEV STORIES / BLOG POSTS  —  loaded from Markdown files.
 // ============================================================================
 //
-//  This file holds the short details for each post (title, brief, cover).
-//  The ARTICLE TEXT for each post lives in its own Markdown file:
+//  Every post is ONE Markdown file in   content/stories/<id>.md
+//  The filename becomes the URL:  content/stories/casim.md -> /dev-stories/casim
 //
-//        content/stories/<id>.md
+//  Each file starts with a small details block between two --- lines
+//  (the "frontmatter"), followed by the article text:
 //
-//  e.g. the post with id "casim" reads its body from
-//       content/stories/casim.md
+//        ---
+//        title: My Post Headline
+//        brief: One-line summary shown on cards and the list page.
+//        order: 4
+//        ---
 //
-//  --------------------------------------------------------------------------
-//  TO EDIT A POST'S ARTICLE:  open content/stories/<id>.md and paste/type
-//  freely. No quotes, brackets, or backticks — just write. Formatting markers:
+//        The article starts here. Write freely — no quotes or brackets.
+//
+//  Frontmatter fields (one per line, "name: value"):
+//        title          the post headline.
+//        brief          one-line summary (shown on cards, list, and post intro).
+//        order          posts are sorted by this number, lowest first.
+//        cover          OPTIONAL cover image path. Defaults to
+//                       /assets/placeholders/<id>.svg — only add this line if
+//                       your image is a .png/.jpg or has a different name,
+//                       e.g.  cover: /assets/placeholders/lookingup.png
+//        coverPosition  OPTIONAL — which part of the cover stays visible when
+//                       it's cropped to fit. Default is "center". Use "left",
+//                       "right", "top", "bottom", or a pair like "25% 50%".
+//        draft          set to true to hide the post from the site entirely.
+//
+//  Article formatting markers (below the closing ---):
 //        ## Heading        ### Smaller heading        > Pull-quote
 //        **bold**          *italic*        - bullet item        1. numbered
 //  Leave a blank line between paragraphs.
 //
-//  TO EDIT THE TITLE / SUMMARY:  change the "quotes" below.
-//
-//  TO ADD A NEW POST:  copy a { ... } block below, give it a new unique `id`,
-//  then create a matching content/stories/<that-id>.md file and a cover image
-//  at public/assets/placeholders/<that-id>.svg
-//
-//  COVER IMAGE:  by default the cover is public/assets/placeholders/<id>.svg
-//  If your image is a .png/.jpg (or a different name), add a `cover:` line to
-//  that post, e.g.  cover: "/assets/placeholders/lookingup.png"
+//  TO ADD A POST:    create content/stories/<new-id>.md with a block like the
+//                    one above, and drop a cover image at
+//                    public/assets/placeholders/<new-id>.svg
+//  TO REMOVE A POST: delete its .md file — or add  draft: true  to its
+//                    frontmatter to keep it around unpublished.
 // ============================================================================
+//
+//  NOTE FOR DEVELOPERS: this module reads the filesystem, so it is
+//  server-only (pages, generateStaticParams, ...). Client components may only
+//  import the Story TYPE from here:  import type { Story } from "@/lib/stories"
+
+import { readdirSync, readFileSync } from "fs";
+import path from "path";
 
 export type Story = {
-  id: string; // unique slug -> URL, .md filename, and cover image name
-  title: string; // the post headline
-  brief: string; // one-line summary (shown on cards, list, and post intro)
-  cover?: string; // OPTIONAL cover image path. Only needed if your image isn't
-  //   public/assets/placeholders/<id>.svg — e.g. for a .png or .jpg.
-  //   Example: cover: "/assets/placeholders/lookingup.png"
-  coverPosition?: string; // OPTIONAL — which part of the cover stays visible
-  //   when it's cropped to fit. Default is "center". Use "left", "right",
-  //   "top", "bottom", or a pair like "25% 50%".
+  id: string; // filename without .md -> the URL slug
+  title: string;
+  brief: string;
+  cover: string; // resolved cover image URL (frontmatter `cover` or default)
+  coverPosition?: string;
 };
 
-// The cover image URL for a story. Uses the story's `cover` if set, otherwise
-// falls back to public/assets/placeholders/<id>.svg
-export function storyCover(story: Story): string {
-  return story.cover ?? `/assets/placeholders/${story.id}.svg`;
+const STORIES_DIR = path.join(process.cwd(), "content", "stories");
+
+type Frontmatter = Record<string, string>;
+
+// Split a file into its frontmatter block and the article body. Forgiving by
+// design: files without a frontmatter block (or with an unclosed one) are
+// treated as all body, and frontmatter lines that aren't "name: value" are
+// skipped rather than rejected.
+function splitFrontmatter(raw: string): { meta: Frontmatter; body: string } {
+  const lines = raw.replace(/^\uFEFF/, "").split(/\r?\n/); // strip BOM if present
+  if (lines[0]?.trim() !== "---") return { meta: {}, body: raw };
+
+  const meta: Frontmatter = {};
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      return { meta, body: lines.slice(i + 1).join("\n") };
+    }
+    // Split on the FIRST colon only, so values may contain colons
+    // (e.g.  title: Looking Up: Our First Game).
+    const sep = lines[i].indexOf(":");
+    if (sep === -1) continue;
+    const key = lines[i].slice(0, sep).trim();
+    let value = lines[i].slice(sep + 1).trim();
+    // Surrounding quotes are allowed but not required.
+    if (value.length >= 2 && (value[0] === '"' || value[0] === "'") && value.endsWith(value[0])) {
+      value = value.slice(1, -1);
+    }
+    if (key) meta[key] = value;
+  }
+  return { meta: {}, body: raw };
 }
 
-export const STORIES: Story[] = [
-  {
-    id: "story-1",
-    title: "Loading...",
-    brief: "This story isn't quite ready yet, we thank you for your patience.",
-  },
-  {
-    id: "lookingup",
-    title: "Looking Up: Our First Game",
-    brief: "We didn’t just build our first game — we learned how to make games by making it. ",
-    cover: "/assets/placeholders/lookingup.png",
-    coverPosition: "left",
-  },
-  {
-    id: "story-3",
-    title: "Loading...",
-    brief: "This story isn't quite ready yet, we thank you for your patience.",
-  },
-];
+type LoadedStory = Story & { order: number; draft: boolean; body: string };
 
-export function getStoryById(id: string): Story | undefined {
-  return STORIES.find((s) => s.id === id);
+function loadStory(file: string): LoadedStory {
+  const id = file.replace(/\.md$/, "");
+  const raw = readFileSync(path.join(STORIES_DIR, file), "utf8");
+  const { meta, body } = splitFrontmatter(raw);
+  const order = Number(meta.order);
+  return {
+    id,
+    title: meta.title || id,
+    brief: meta.brief || "",
+    cover: meta.cover || `/assets/placeholders/${id}.svg`,
+    coverPosition: meta.coverPosition || undefined,
+    order: Number.isFinite(order) ? order : Infinity, // unordered posts go last
+    draft: (meta.draft || "").trim().toLowerCase() === "true",
+    body,
+  };
+}
+
+function loadAll(): LoadedStory[] {
+  let files: string[];
+  try {
+    files = readdirSync(STORIES_DIR);
+  } catch {
+    return [];
+  }
+  return files
+    .filter((f) => f.endsWith(".md"))
+    .map(loadStory)
+    .filter((s) => !s.draft)
+    .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+}
+
+// All published stories in display order, without article bodies (so lists
+// and the home-page carousel don't carry the full article text around).
+export function getStories(): Story[] {
+  return loadAll().map((s) => ({
+    id: s.id,
+    title: s.title,
+    brief: s.brief,
+    cover: s.cover,
+    coverPosition: s.coverPosition,
+  }));
+}
+
+// One published story including its article body, or undefined if there is
+// no such post (or it's a draft).
+export function getStory(slug: string): (Story & { body: string }) | undefined {
+  return loadAll().find((s) => s.id === slug);
 }


### PR DESCRIPTION
## What

Dev stories are now fully markdown-driven. Each post is a single file in `content/stories/<id>.md` with a frontmatter block (`title`, `brief`, `order`, optional `cover` / `coverPosition` / `draft`) followed by the article text. Adding a post no longer requires code changes — drop in a markdown file and push.

## Changes

- `lib/stories.ts`: the hardcoded `STORIES` array is replaced by a server-side loader that scans `content/stories/*.md`, parses frontmatter (hand-rolled, forgiving, no new dependencies), skips `draft: true` posts, and sorts by `order`. The file header doubles as editor instructions.
- `DevStoriesCarousel` takes `stories` as a prop (client components can't read the filesystem); the home page passes `getStories()` in.
- List page and post page read from the loader; the post page's own file-reading helper is gone.
- All story files got frontmatter. `story-4/5/6` are `draft: true` (they were unpublished placeholders before, so the visible site is unchanged).
- `content/drafts/casim.md` moved into `content/stories/` with frontmatter, replacing its outdated restore instructions; it **stays unpublished** (`draft: true`). Its bullet lists were fixed to render properly (`-item` → `- item`). To publish it later, delete the `draft: true` line.

## Verified

- `npm run build` (static export) generates exactly `/dev-stories/story-1`, `/lookingup`, `/story-3` in order — the same set as today; drafts appear nowhere in the output.
- Exported HTML spot-checked: headings/bullets render as real markup, no frontmatter leaks, carousel and list pages populated.
- Deploy workflow needs no changes — it builds from source on push to main, so markdown edits publish automatically.